### PR TITLE
proposal data via wagmi read returns successfully

### DIFF
--- a/apps/next/.env
+++ b/apps/next/.env
@@ -4,3 +4,4 @@ NEXT_PUBLIC_SITE_DESCRIPTION='Only one degree of separation lies between everyon
 NEXT_PUBLIC_TWITTER_HANDLE='pblcasmbly'
 NEXT_PUBLIC_WEBSITE_URL='https://assemble-package.public---assembly.com'
 NEXT_PUBLIC_NETWORK_URL=1
+NEXT_PUBLIC_INFURA_KEY='https://mainnet.infura.io/v3/54456f5135d64d63b31ff4a777e7c9b1'

--- a/apps/next/pages/providers.tsx
+++ b/apps/next/pages/providers.tsx
@@ -13,13 +13,18 @@ function PrintManagerProviderData() {
 }
 
 function PrintGovernorProviderData() {
-  const { proposalId, proposalDetails } = useGovernorProvider()
+  const { proposalId, proposalDetails, proposalArray } = useGovernorProvider()
   return (
     <>
       <RawDisplayer data={proposalId} />
       <RawDisplayer data={proposalDetails} />
     </>
   )
+}
+
+function PrintAllProposals() {
+  const { proposalArray } = useGovernorProvider()
+  return <RawDisplayer data={proposalArray} />
 }
 
 function Providers() {
@@ -31,6 +36,7 @@ function Providers() {
           <PrintManagerProviderData />
           <GovernorProvider proposalId="0x892CC8EE0DDE04122318FED5C70FEA674BDFC46675142E9593FC3F338EDE6605">
             <PrintGovernorProviderData />
+            <PrintAllProposals />
           </GovernorProvider>
         </ManagerProvider>
       </div>

--- a/apps/next/pages/providers.tsx
+++ b/apps/next/pages/providers.tsx
@@ -13,7 +13,7 @@ function PrintManagerProviderData() {
 }
 
 function PrintGovernorProviderData() {
-  const { proposalId, proposalDetails, proposalArray } = useGovernorProvider()
+  const { proposalId, proposalDetails } = useGovernorProvider()
   return (
     <>
       <RawDisplayer data={proposalId} />
@@ -32,9 +32,9 @@ function Providers() {
     <section className="max-w-[1240px] m-auto px-4 gap-8 flex flex-col">
       <Seo title="providers" />
       <div className="bg-slate-300 p-4 rounded-2xl text-black">
-        <ManagerProvider tokenAddress="0x8983eC4B57dbebe8944Af8d4F9D3adBAfEA5b9f1">
+        <ManagerProvider tokenAddress="0xdf9b7d26c8fc806b1ae6273684556761ff02d422">
           <PrintManagerProviderData />
-          <GovernorProvider proposalId="0x892CC8EE0DDE04122318FED5C70FEA674BDFC46675142E9593FC3F338EDE6605">
+          <GovernorProvider proposalId="0xD0FDF3CD81E18DBC88C0F858E4EA00C48E3530A684C52839A4CE24302EDE91C3">
             <PrintGovernorProviderData />
             <PrintAllProposals />
           </GovernorProvider>

--- a/apps/next/pages/providers.tsx
+++ b/apps/next/pages/providers.tsx
@@ -1,5 +1,10 @@
 import { Seo } from '@/components/Seo'
-import { ManagerProvider, useManagerProvider } from '@public-assembly/dao-utils'
+import {
+  ManagerProvider,
+  useManagerProvider,
+  GovernorProvider,
+  useGovernorProvider,
+} from '@public-assembly/dao-utils'
 import { RawDisplayer } from '../components'
 
 function PrintManagerProviderData() {
@@ -7,13 +12,26 @@ function PrintManagerProviderData() {
   return <RawDisplayer data={daoAddresses} />
 }
 
+function PrintGovernorProviderData() {
+  const { proposalId, proposalDetails } = useGovernorProvider()
+  return (
+    <>
+      <RawDisplayer data={proposalId} />
+      <RawDisplayer data={proposalDetails} />
+    </>
+  )
+}
+
 function Providers() {
   return (
     <section className="max-w-[1240px] m-auto px-4 gap-8 flex flex-col">
       <Seo title="providers" />
       <div className="bg-slate-300 p-4 rounded-2xl text-black">
-        <ManagerProvider tokenAddress="0xdf9b7d26c8fc806b1ae6273684556761ff02d422">
+        <ManagerProvider tokenAddress="0x8983eC4B57dbebe8944Af8d4F9D3adBAfEA5b9f1">
           <PrintManagerProviderData />
+          <GovernorProvider proposalId="0x892CC8EE0DDE04122318FED5C70FEA674BDFC46675142E9593FC3F338EDE6605">
+            <PrintGovernorProviderData />
+          </GovernorProvider>
         </ManagerProvider>
       </div>
     </section>

--- a/packages/dao-utils/src/abi/governorAbi.ts
+++ b/packages/dao-utils/src/abi/governorAbi.ts
@@ -1,0 +1,1550 @@
+export const governorAbi = [
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_manager',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'constructor',
+  },
+  {
+    inputs: [],
+    name: 'ADDRESS_ZERO',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ALREADY_INITIALIZED',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ALREADY_VOTED',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'BELOW_PROPOSAL_THRESHOLD',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'DELEGATE_CALL_FAILED',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'EXPIRED_SIGNATURE',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'INITIALIZING',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'INVALID_CANCEL',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'INVALID_PROPOSAL_THRESHOLD_BPS',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'INVALID_QUORUM_THRESHOLD_BPS',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'INVALID_SIGNATURE',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'INVALID_TARGET',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'impl',
+        type: 'address',
+      },
+    ],
+    name: 'INVALID_UPGRADE',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'INVALID_VOTE',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'INVALID_VOTING_DELAY',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'INVALID_VOTING_PERIOD',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'NOT_INITIALIZING',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ONLY_CALL',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ONLY_DELEGATECALL',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ONLY_MANAGER',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ONLY_OWNER',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ONLY_PENDING_OWNER',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ONLY_PROXY',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ONLY_UUPS',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ONLY_VETOER',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'PROPOSAL_ALREADY_EXECUTED',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'PROPOSAL_DOES_NOT_EXIST',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'proposalId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'PROPOSAL_EXISTS',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'PROPOSAL_LENGTH_MISMATCH',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'proposalId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'PROPOSAL_NOT_QUEUED',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'PROPOSAL_TARGET_MISSING',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'PROPOSAL_UNSUCCESSFUL',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'UNSAFE_CAST',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'UNSUPPORTED_UUID',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'VOTING_NOT_STARTED',
+    type: 'error',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'version',
+        type: 'uint256',
+      },
+    ],
+    name: 'Initialized',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'canceledOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnerCanceled',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'pendingOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnerPending',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'prevOwner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnerUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'proposalId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'ProposalCanceled',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'proposalId',
+        type: 'bytes32',
+      },
+      {
+        indexed: false,
+        internalType: 'address[]',
+        name: 'targets',
+        type: 'address[]',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256[]',
+        name: 'values',
+        type: 'uint256[]',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes[]',
+        name: 'calldatas',
+        type: 'bytes[]',
+      },
+      {
+        indexed: false,
+        internalType: 'string',
+        name: 'description',
+        type: 'string',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'descriptionHash',
+        type: 'bytes32',
+      },
+      {
+        components: [
+          {
+            internalType: 'address',
+            name: 'proposer',
+            type: 'address',
+          },
+          {
+            internalType: 'uint32',
+            name: 'timeCreated',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint32',
+            name: 'againstVotes',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint32',
+            name: 'forVotes',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint32',
+            name: 'abstainVotes',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint32',
+            name: 'voteStart',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint32',
+            name: 'voteEnd',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint32',
+            name: 'proposalThreshold',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint32',
+            name: 'quorumVotes',
+            type: 'uint32',
+          },
+          {
+            internalType: 'bool',
+            name: 'executed',
+            type: 'bool',
+          },
+          {
+            internalType: 'bool',
+            name: 'canceled',
+            type: 'bool',
+          },
+          {
+            internalType: 'bool',
+            name: 'vetoed',
+            type: 'bool',
+          },
+        ],
+        indexed: false,
+        internalType: 'struct GovernorTypesV1.Proposal',
+        name: 'proposal',
+        type: 'tuple',
+      },
+    ],
+    name: 'ProposalCreated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'proposalId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'ProposalExecuted',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'proposalId',
+        type: 'bytes32',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'eta',
+        type: 'uint256',
+      },
+    ],
+    name: 'ProposalQueued',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'prevBps',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'newBps',
+        type: 'uint256',
+      },
+    ],
+    name: 'ProposalThresholdBpsUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'proposalId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'ProposalVetoed',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'prevBps',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'newBps',
+        type: 'uint256',
+      },
+    ],
+    name: 'QuorumVotesBpsUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'impl',
+        type: 'address',
+      },
+    ],
+    name: 'Upgraded',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'prevVetoer',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'newVetoer',
+        type: 'address',
+      },
+    ],
+    name: 'VetoerUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'voter',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'proposalId',
+        type: 'bytes32',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'support',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'weight',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'string',
+        name: 'reason',
+        type: 'string',
+      },
+    ],
+    name: 'VoteCast',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'prevVotingDelay',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'newVotingDelay',
+        type: 'uint256',
+      },
+    ],
+    name: 'VotingDelayUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'prevVotingPeriod',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'newVotingPeriod',
+        type: 'uint256',
+      },
+    ],
+    name: 'VotingPeriodUpdated',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'DOMAIN_SEPARATOR',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'MAX_PROPOSAL_THRESHOLD_BPS',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'MAX_QUORUM_THRESHOLD_BPS',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'MAX_VOTING_DELAY',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'MAX_VOTING_PERIOD',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'MIN_PROPOSAL_THRESHOLD_BPS',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'MIN_QUORUM_THRESHOLD_BPS',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'MIN_VOTING_DELAY',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'MIN_VOTING_PERIOD',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'VOTE_TYPEHASH',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'acceptOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'burnVetoer',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_proposalId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'cancel',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'cancelOwnershipTransfer',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_proposalId',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'uint256',
+        name: '_support',
+        type: 'uint256',
+      },
+    ],
+    name: 'castVote',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_voter',
+        type: 'address',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_proposalId',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'uint256',
+        name: '_support',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_deadline',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint8',
+        name: '_v',
+        type: 'uint8',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_r',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_s',
+        type: 'bytes32',
+      },
+    ],
+    name: 'castVoteBySig',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_proposalId',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'uint256',
+        name: '_support',
+        type: 'uint256',
+      },
+      {
+        internalType: 'string',
+        name: '_reason',
+        type: 'string',
+      },
+    ],
+    name: 'castVoteWithReason',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address[]',
+        name: '_targets',
+        type: 'address[]',
+      },
+      {
+        internalType: 'uint256[]',
+        name: '_values',
+        type: 'uint256[]',
+      },
+      {
+        internalType: 'bytes[]',
+        name: '_calldatas',
+        type: 'bytes[]',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_descriptionHash',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: '_proposer',
+        type: 'address',
+      },
+    ],
+    name: 'execute',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_proposalId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'getProposal',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'address',
+            name: 'proposer',
+            type: 'address',
+          },
+          {
+            internalType: 'uint32',
+            name: 'timeCreated',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint32',
+            name: 'againstVotes',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint32',
+            name: 'forVotes',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint32',
+            name: 'abstainVotes',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint32',
+            name: 'voteStart',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint32',
+            name: 'voteEnd',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint32',
+            name: 'proposalThreshold',
+            type: 'uint32',
+          },
+          {
+            internalType: 'uint32',
+            name: 'quorumVotes',
+            type: 'uint32',
+          },
+          {
+            internalType: 'bool',
+            name: 'executed',
+            type: 'bool',
+          },
+          {
+            internalType: 'bool',
+            name: 'canceled',
+            type: 'bool',
+          },
+          {
+            internalType: 'bool',
+            name: 'vetoed',
+            type: 'bool',
+          },
+        ],
+        internalType: 'struct GovernorTypesV1.Proposal',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_account',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_timestamp',
+        type: 'uint256',
+      },
+    ],
+    name: 'getVotes',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address[]',
+        name: '_targets',
+        type: 'address[]',
+      },
+      {
+        internalType: 'uint256[]',
+        name: '_values',
+        type: 'uint256[]',
+      },
+      {
+        internalType: 'bytes[]',
+        name: '_calldatas',
+        type: 'bytes[]',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_descriptionHash',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: '_proposer',
+        type: 'address',
+      },
+    ],
+    name: 'hashProposal',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_treasury',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_token',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_vetoer',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_votingDelay',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_votingPeriod',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_proposalThresholdBps',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_quorumThresholdBps',
+        type: 'uint256',
+      },
+    ],
+    name: 'initialize',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_account',
+        type: 'address',
+      },
+    ],
+    name: 'nonce',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'owner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'pendingOwner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_proposalId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'proposalDeadline',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_proposalId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'proposalEta',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_proposalId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'proposalSnapshot',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'proposalThreshold',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'proposalThresholdBps',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_proposalId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'proposalVotes',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address[]',
+        name: '_targets',
+        type: 'address[]',
+      },
+      {
+        internalType: 'uint256[]',
+        name: '_values',
+        type: 'uint256[]',
+      },
+      {
+        internalType: 'bytes[]',
+        name: '_calldatas',
+        type: 'bytes[]',
+      },
+      {
+        internalType: 'string',
+        name: '_description',
+        type: 'string',
+      },
+    ],
+    name: 'propose',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'proxiableUUID',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_proposalId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'queue',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'eta',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'quorum',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'quorumThresholdBps',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'safeTransferOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_proposalId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'state',
+    outputs: [
+      {
+        internalType: 'enum GovernorTypesV1.ProposalState',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'token',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'transferOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'treasury',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_newProposalThresholdBps',
+        type: 'uint256',
+      },
+    ],
+    name: 'updateProposalThresholdBps',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_newQuorumVotesBps',
+        type: 'uint256',
+      },
+    ],
+    name: 'updateQuorumThresholdBps',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_newVetoer',
+        type: 'address',
+      },
+    ],
+    name: 'updateVetoer',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_newVotingDelay',
+        type: 'uint256',
+      },
+    ],
+    name: 'updateVotingDelay',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_newVotingPeriod',
+        type: 'uint256',
+      },
+    ],
+    name: 'updateVotingPeriod',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_newImpl',
+        type: 'address',
+      },
+    ],
+    name: 'upgradeTo',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_newImpl',
+        type: 'address',
+      },
+      {
+        internalType: 'bytes',
+        name: '_data',
+        type: 'bytes',
+      },
+    ],
+    name: 'upgradeToAndCall',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_proposalId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'veto',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'vetoer',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'votingDelay',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'votingPeriod',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const

--- a/packages/dao-utils/src/context/GovernorProvider.tsx
+++ b/packages/dao-utils/src/context/GovernorProvider.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react'
+import { useContractRead } from 'wagmi'
+import { governorAbi } from '../abi/governorAbi'
+import { useManagerProvider } from './ManagerProvider'
+
+export interface GovernorProviderProps {
+  children?: React.ReactNode
+  proposalId?: string
+}
+
+export interface GovernorReturnTypes {
+  tokenAddress?: string
+  governorAddress?: string
+  proposalId?: string
+  proposalDetails?: {
+    proposer: string
+    timeCreated: number
+    againstVotes: number
+    forVotes: number
+    abstainVotes: number
+    voteStart: number
+    voteEnd: number
+    proposalThreshold: number
+    quorumVotes: number
+    executed: boolean
+    canceled: boolean
+    vetoed: boolean
+  }
+}
+
+const GovernorContext = React.createContext({} as GovernorReturnTypes)
+
+export function GovernorProvider({ children, proposalId }: GovernorProviderProps) {
+  const {
+    tokenAddress,
+    daoAddresses: { governorAddress },
+  } = useManagerProvider()
+
+  const { data: getProposal } = useContractRead({
+    addressOrName: governorAddress as string,
+    contractInterface: governorAbi,
+    functionName: 'getProposal',
+    args: [proposalId],
+  })
+
+  console.log(getProposal)
+
+  const proposalDetails = React.useMemo(() => {
+    return {
+      proposer: getProposal?.proposer,
+      timeCreated: getProposal?.timeCreated,
+      againstVotes: getProposal?.againstVotes,
+      forVotes: getProposal?.forVotes,
+      abstainVotes: getProposal?.abstainVotes,
+      voteStart: getProposal?.voteStart,
+      voteEnd: getProposal?.voteEnd,
+      proposalThreshold: getProposal?.proposalThreshold,
+      quorumVotes: getProposal?.quorumVotes,
+      executed: getProposal?.executed,
+      canceled: getProposal?.canceled,
+      vetoed: getProposal?.vetoed,
+    }
+  }, [getProposal])
+
+  return (
+    <GovernorContext.Provider
+      value={{ tokenAddress, governorAddress, proposalId, proposalDetails }}>
+      {children}
+    </GovernorContext.Provider>
+  )
+}
+
+// Access the context value of the GovernorProvider
+export function useGovernorProvider() {
+  return React.useContext(GovernorContext)
+}

--- a/packages/dao-utils/src/context/ManagerProvider.tsx
+++ b/packages/dao-utils/src/context/ManagerProvider.tsx
@@ -10,6 +10,9 @@ export interface ManagerProviderProps {
   tokenAddress?: string
 }
 
+/**
+ * TODO: fix typings, strings should become addresses
+ */
 export interface ManagerReturnTypes {
   tokenAddress?: string
   daoAddresses: {

--- a/packages/dao-utils/src/context/index.ts
+++ b/packages/dao-utils/src/context/index.ts
@@ -1,2 +1,3 @@
 export * from './AuctionProvider'
 export * from './ManagerProvider'
+export * from './GovernorProvider'

--- a/packages/dao-utils/src/index.ts
+++ b/packages/dao-utils/src/index.ts
@@ -13,6 +13,8 @@ import {
 
 import { useAuctionProvider, AuctionProvider } from './context/AuctionProvider'
 
+import { useGovernorProvider, GovernorProvider } from './context/GovernorProvider'
+
 import { useManagerProvider, ManagerProvider } from './context/ManagerProvider'
 
 import { shortenAddress, zoraApiFetcher, etherscanLink } from './lib'
@@ -44,6 +46,8 @@ export {
    */
   AuctionProvider,
   useAuctionProvider,
+  GovernorProvider,
+  useGovernorProvider,
   ManagerProvider,
   useManagerProvider,
 }


### PR DESCRIPTION
adds the `GovernorProvider`, and `useGovernorProvider` hook

the `GovernorProvider` houses a contract read call that provided with a bytes encoded `proposalId` returns the information defined in the struct called `Proposal`, shown [here](https://github.com/ourzora/nouns-protocol/blob/main/src/governance/governor/types/GovernorTypesV1.sol) 